### PR TITLE
Add Stripe checkout edge functions

### DIFF
--- a/supabase/functions/create-checkout-session/index.ts
+++ b/supabase/functions/create-checkout-session/index.ts
@@ -1,0 +1,43 @@
+import { serve } from 'https://deno.land/std@0.203.0/http/server.ts';
+import Stripe from 'https://esm.sh/stripe@14?target=denonext';
+
+const stripeSecret = Deno.env.get('STRIPE_SECRET');
+const siteUrl = Deno.env.get('SITE_URL') ?? 'http://localhost:3000';
+
+if (!stripeSecret) {
+  console.error('Missing STRIPE_SECRET environment variable');
+}
+
+const stripe = new Stripe(stripeSecret!, { apiVersion: '2024-04-10' });
+
+serve(async (req) => {
+  if (req.method !== 'POST') {
+    return new Response('Method not allowed', { status: 405 });
+  }
+
+  const { priceId, scanId, fixId, userEmail } = await req.json();
+
+  if (!priceId || !scanId || !fixId || !userEmail) {
+    return new Response('Missing parameters', { status: 400 });
+  }
+
+  try {
+    const session = await stripe.checkout.sessions.create({
+      mode: 'payment',
+      payment_method_types: ['card'],
+      customer_email: userEmail,
+      line_items: [{ price: priceId, quantity: 1 }],
+      metadata: { scanId, fixId },
+      success_url: `${siteUrl}/payment-success?scan_id=${scanId}`,
+      cancel_url: `${siteUrl}/fixes/${scanId}`,
+    });
+
+    return new Response(JSON.stringify({ sessionId: session.id }), {
+      headers: { 'Content-Type': 'application/json' },
+      status: 200,
+    });
+  } catch (err) {
+    console.error('Stripe error:', err);
+    return new Response('Unable to create session', { status: 500 });
+  }
+});

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -1,0 +1,51 @@
+import { serve } from 'https://deno.land/std@0.203.0/http/server.ts';
+import Stripe from 'https://esm.sh/stripe@14?target=denonext';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const stripeSecret = Deno.env.get('STRIPE_SECRET');
+const webhookSecret = Deno.env.get('STRIPE_WEBHOOK_SECRET');
+const supabaseUrl = Deno.env.get('SUPABASE_URL');
+const supabaseKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+
+const stripe = new Stripe(stripeSecret!, { apiVersion: '2024-04-10' });
+const cryptoProvider = Stripe.createSubtleCryptoProvider();
+const supabase = createClient(supabaseUrl!, supabaseKey!);
+
+serve(async (req) => {
+  const signature = req.headers.get('Stripe-Signature');
+  const body = await req.text();
+  let event;
+  try {
+    event = await stripe.webhooks.constructEventAsync(
+      body,
+      signature!,
+      webhookSecret!,
+      undefined,
+      cryptoProvider,
+    );
+  } catch (err) {
+    console.error('Webhook error:', err);
+    return new Response('Invalid signature', { status: 400 });
+  }
+
+  if (event.type === 'checkout.session.completed') {
+    const session = event.data.object as Stripe.Checkout.Session;
+    const scanId = session.metadata?.scanId;
+    const fixId = session.metadata?.fixId;
+    const userEmail = session.customer_email;
+
+    if (scanId && fixId && userEmail) {
+      await supabase.from('purchases').upsert({
+        scan_id: scanId,
+        fix_id: fixId,
+        user_email: userEmail,
+        status: 'paid',
+        stripe_session_id: session.id,
+      });
+    }
+  }
+
+  return new Response(JSON.stringify({ received: true }), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+});


### PR DESCRIPTION
## Summary
- add `create-checkout-session` Supabase edge function
- add `stripe-webhook` edge function for purchase updates

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863040e4a6483259add8430a80fe1a5