### PR TITLE
Add deployment docs and nginx config

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,6 @@ This is an automated website security/exposure audit application.
 - **Subscription Model**: Implement a rate-limiting and subscription portal using Stripe to offer premium features, higher scan quotas, and advanced reporting.
 - **Theme Toggle**: Add a light-mode theme for users who prefer it over the default dark "hacker" theme.
 - **Custom Report Branding**: Allow premium users to add their own logo and branding to the generated PDF reports.
+## Deployment
+
+See [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) for instructions on deploying with Portainer and configuring an Nginx reverse proxy.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,45 @@
+# Deployment Guide
+
+This guide explains how to deploy the audit application using Portainer and configure an Nginx reverse proxy with Let's Encrypt TLS.
+
+## 1. Build with Portainer
+
+1. Log in to Portainer.
+2. Navigate to **Stacks** and choose **Add stack**.
+3. Paste the contents of `docker-deploy.yaml` or upload it from the repository.
+4. Deploy the stack. Portainer builds the Docker image from the included `Dockerfile`.
+5. The stack exposes port **3001** inside the container and maps it to host port **8087** as defined in `docker-deploy.yaml`:
+   ```yaml
+   services:
+     audit:
+       ports:
+         - "8087:3001"
+   ```
+
+## 2. Configure Nginx Reverse Proxy
+
+Use an external Nginx instance to route traffic for `audit.redfoxsecurities.com` to the container and obtain a Let's Encrypt certificate.
+
+1. Install Nginx and Certbot on the host that will serve as the reverse proxy.
+2. Create an Nginx site configuration similar to the following:
+   ```nginx
+   server {
+       listen 80;
+       server_name audit.redfoxsecurities.com;
+       location / {
+           proxy_pass http://localhost:8087;
+           proxy_set_header Host $host;
+           proxy_set_header X-Real-IP $remote_addr;
+           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+           proxy_set_header X-Forwarded-Proto $scheme;
+       }
+   }
+   ```
+3. Enable the configuration and reload Nginx.
+4. Obtain and install a Let's Encrypt certificate using Certbot:
+   ```bash
+   sudo certbot --nginx -d audit.redfoxsecurities.com
+   ```
+   Certbot updates the Nginx configuration to redirect HTTP to HTTPS and automatically renew the certificate.
+
+With these steps completed, requests to `https://audit.redfoxsecurities.com` will terminate TLS at the reverse proxy and forward to the container running on port 8087.

--- a/nginx/audit.redfoxsecurities.com.conf
+++ b/nginx/audit.redfoxsecurities.com.conf
@@ -1,0 +1,12 @@
+server {
+    listen 80;
+    server_name audit.redfoxsecurities.com;
+
+    location / {
+        proxy_pass http://localhost:8087;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}


### PR DESCRIPTION
## Summary
- add deployment instructions linking to docker-deploy.yaml
- document reverse proxy setup with Let's Encrypt
- include example nginx site config

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68630410b20c8325a63d52577bfe71b3