### PR TITLE
Fix title, generator meta and favicon

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,10 +2,9 @@
 <html lang="en">
 	<head>
 		<meta charset="UTF-8" />
-		<link rel="icon" type="image/svg+xml" href="/vite.svg" />
-		<meta name="generator" content="Hostinger Horizons" />
-		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<title>Hostinger Horizons</title>
+                <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+                <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+                <title>RedFox Securities Audit Platform</title>
 	</head>
 	<body>
 		<div id="root"></div>


### PR DESCRIPTION
## Summary
- update project title in `index.html`
- remove Hostinger Horizons generator meta tag
- point favicon to production path

## Testing
- `npm test` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68634668672483259b14d4ac9b7cbfe0