### PR TITLE
Remove node-fetch use

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,5 +1,4 @@
 import express from 'express';
-import fetch from 'node-fetch';
 import cors from 'cors';
 import dotenv from 'dotenv';
 import path from 'path';


### PR DESCRIPTION
## Summary
- remove the `node-fetch` import from `server.js` since Node 18 provides global `fetch`

## Testing
- `npm test`
- `npm run build`
- `docker build -t rfx-audit .` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686346a4b3908325947b127256d89f1d