### PR TITLE
Add .dockerignore for leaner Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+node_modules
+.git
+docs
+issues
+supabase
+tools
+.dockerignore
+README.md
+.eslintrc.json
+.eslintignore
+.env
+.env.*
+*.log
+*.md


### PR DESCRIPTION
## Summary
- create `.dockerignore` to keep docs, issues, git metadata and other files out of the container

## Testing
- `npm test` *(fails: ESLint couldn't find a config file)*
- `docker build -t rfx-audit:old .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_686346ad69fc832586702b60ac2c1de7