### PR TITLE
Update ports from 8087 to 8085

### DIFF
--- a/docker-deploy.yaml
+++ b/docker-deploy.yaml
@@ -9,6 +9,6 @@ services:
     image: rfx-audit:latest       # tag written to local registry
     container_name: rfx-audit-v2
     ports:
-      - "8087:3001"
+      - "8085:3001"
     
     restart: unless-stopped

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -8,12 +8,12 @@ This guide explains how to deploy the audit application using Portainer and conf
 2. Navigate to **Stacks** and choose **Add stack**.
 3. Paste the contents of `docker-deploy.yaml` or upload it from the repository.
 4. Deploy the stack. Portainer builds the Docker image from the included `Dockerfile`.
-5. The stack exposes port **3001** inside the container and maps it to host port **8087** as defined in `docker-deploy.yaml`:
+5. The stack exposes port **3001** inside the container and maps it to host port **8085** as defined in `docker-deploy.yaml`:
    ```yaml
    services:
      audit:
        ports:
-         - "8087:3001"
+         - "8085:3001"
    ```
 
 ## 2. Configure Nginx Reverse Proxy
@@ -27,7 +27,7 @@ Use an external Nginx instance to route traffic for `audit.redfoxsecurities.com`
        listen 80;
        server_name audit.redfoxsecurities.com;
        location / {
-           proxy_pass http://localhost:8087;
+           proxy_pass http://localhost:8085;
            proxy_set_header Host $host;
            proxy_set_header X-Real-IP $remote_addr;
            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -42,4 +42,4 @@ Use an external Nginx instance to route traffic for `audit.redfoxsecurities.com`
    ```
    Certbot updates the Nginx configuration to redirect HTTP to HTTPS and automatically renew the certificate.
 
-With these steps completed, requests to `https://audit.redfoxsecurities.com` will terminate TLS at the reverse proxy and forward to the container running on port 8087.
+With these steps completed, requests to `https://audit.redfoxsecurities.com` will terminate TLS at the reverse proxy and forward to the container running on port 8085.

--- a/nginx/audit.redfoxsecurities.com.conf
+++ b/nginx/audit.redfoxsecurities.com.conf
@@ -3,7 +3,7 @@ server {
     server_name audit.redfoxsecurities.com;
 
     location / {
-        proxy_pass http://localhost:8087;
+        proxy_pass http://localhost:8085;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## Summary
- update host port in `docker-deploy.yaml`
- point nginx reverse proxy to port `8085`
- document new port mapping in deployment guide

## Testing
- `npm test` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_6863f6eee2ac8325934d0ff6e41c2fb3