### PR TITLE
Fix missing node deps and audit warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1985,13 +1985,10 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.23.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.7.tgz",
-      "integrity": "sha512-w06OXVOFso7LcbzMiDGt+3X7Rh7Ho8MmgPoWU3rarH+8upf+wSU/grlGbWzQyr3DkdN6ZeuMFjpdwW0Q+HxobA==",
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
+      "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
       "license": "MIT",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -8329,12 +8326,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-      "license": "MIT"
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",


### PR DESCRIPTION
## Summary
- install npm deps
- run `npm audit fix` to update lockfile

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6863fdfe162c832587678d1bbf0a70ab